### PR TITLE
do not specify min kubernetes provider version

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -5,6 +5,5 @@ terraform {
     aws        = "~> 2.50"
     helm       = "~> 1.0"
     random     = "~> 2.2"
-    kubernetes = "~> 1.11"
   }
 }


### PR DESCRIPTION
currently this leads to a new copy of kubernetes provider which is not inherited from the root module